### PR TITLE
[Frontend] Add lighting and shinines, fixes #7, closes #5

### DIFF
--- a/frontend/src/components/figure/index.js
+++ b/frontend/src/components/figure/index.js
@@ -31,20 +31,22 @@ export default function Figure(props) {
 
 	return (
 		<mesh>
-			<meshBasicMaterial
+			<meshPhongMaterial
 				side={THREE.FrontSide}
 				color={0xff0000}
 				vertexColors={THREE.FaceColors}
+				flatShading={true}
 				attach="material"
-			></meshBasicMaterial>
+			></meshPhongMaterial>
 			<primitive attach="geometry" object={foldGeometry.geometry} />
 			<mesh>
-				<meshBasicMaterial
+				<meshPhongMaterial
 					side={THREE.BackSide}
 					color={0x00ff00}
 					vertexColors={THREE.FaceColors}
 					attach="material"
-				></meshBasicMaterial>
+					flatShading={true}
+				></meshPhongMaterial>
 				<primitive attach="geometry" object={foldGeometry.geometry} />
 			</mesh>
 		</mesh>

--- a/frontend/src/components/viewer/index.js
+++ b/frontend/src/components/viewer/index.js
@@ -1,6 +1,6 @@
-import React from "react"
+import React, { useRef } from "react"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
-import { Canvas, extend, useThree } from "react-three-fiber"
+import { Canvas, extend, useThree, useFrame } from "react-three-fiber"
 import Figure from "../../components/figure"
 
 extend({ OrbitControls })
@@ -11,11 +11,17 @@ function SceneConfiguration() {
 		gl: { domElement },
 	} = useThree()
 
+	const lightRef = useRef()
+
+	useFrame(() => {
+		lightRef.current.position.copy(camera.position)
+	})
+
 	return (
 		<>
 			<orbitControls args={[camera, domElement]} />
 			<ambientLight />
-			<pointLight position={[5, 5, 5]} />
+			<pointLight ref={lightRef} intensity={0.5} position={[5, 5, 5]} />
 		</>
 	)
 }


### PR DESCRIPTION
This also invalidates/de prioritizes #5 (Rotate model instead of the whole scene). Due to the architecture of OrbitControls it's not possible to adapt it to only work on scene meshes and implementing #5 would require a custom solution. The one suggested in #5's description does not work reliably. 
OTOH we can easily rotate the light-source with respect to `camera.position`. Unless we plan to have more light-sources or other fixated objects I think this is _good enough_ ™. We can later reopen the issue should it be necessary.

We may also want to move all constants to a separate file? Not sure what is the recommended way of handling that in JS world.