### PR TITLE
Add badges to readme indicating build and deployment status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Origami
+
+| Module | Build | Deploy |
+| ---- | ---- | --- |
+| Frontend | [![Frontend](https://github.com/maciekmm/origami/workflows/Frontend/badge.svg)](https://github.com/maciekmm/origami/actions?query=workflow%3AFrontend) | [![Netlify Status](https://api.netlify.com/api/v1/badges/6771f61e-c7a4-4dd0-b965-b41e1e6f4029/deploy-status)](https://app.netlify.com/sites/origuide/deploys) |
+| Backend | [![Backend](https://github.com/maciekmm/origami/workflows/Backend/badge.svg)](https://github.com/maciekmm/origami/actions?query=workflow%3ABackend) | |
+| Thesis | [![Thesis](https://github.com/maciekmm/origami/workflows/Thesis/badge.svg)](https://github.com/maciekmm/origami/actions?query=workflow%3AThesis) ||


### PR DESCRIPTION
Backend and Thesis do not render because the backend's workflow does not exist and the thesis one was never executed after the rename.