### PR TITLE
Changed edges assignment order in fold producer, closes #112

### DIFF
--- a/backend/solver/origuide/fold/fold_producer.py
+++ b/backend/solver/origuide/fold/fold_producer.py
@@ -21,14 +21,18 @@ class FoldProducer:
         if len(self.base.steady_states) < self.step:
             raise RuntimeError("No steady state to base transition on")
 
-        self.transitions.append(
-            {
+        transition = {
                 **self.base.steady_states[self.step - 1].raw,
                 "frame_inherit": True,
                 "frame_parent": len(self.transitions) - 1,
-                "vertices_coords": self.transitions[-1]["vertices_coords"]
+                "vertices_coords": self.transitions[-1]["vertices_coords"],
             }
-        )
+
+        if self.step < len(self.base.steady_states):
+            transition["edges_assignment"] = self.base.steady_states[self.step].raw["edges_assignment"]
+
+        self.transitions.append(transition)
+
         self.last_steady_frame = len(self.transitions) - 1
         self.encoder.next_step()
 


### PR DESCRIPTION
Now, the new edge assignment will be visible when the given step starts (and not at the next one), so that one can see better which edges will be folded.